### PR TITLE
fix: postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc --module es2020 --outDir lib/esm",
     "build:cjs": "tsc --module commonjs --outDir lib",
-    "postinstall": "npm run build || exit 0",
     "lint": "prettier --check index.ts",
     "test": "node test/index.test.mjs"
   },


### PR DESCRIPTION
Hey Paul,

sorry for this one, but I f this up in my last PR

the postinstall hook should not be there.
I introduced it so it would be able to use the package from github directly, but now it's causing npm installs to build the parent project.

This needs to be removed and we need another npm release :) Sorry again